### PR TITLE
Fix violation on HTML(5)

### DIFF
--- a/mdx_embedly.py
+++ b/mdx_embedly.py
@@ -30,7 +30,7 @@ class EmbedlyPostprocesser(Postprocessor):
         title = "embed.ly"
         return """
 <a class="embedly-card" href="{0}">{1}</a>
-<script async src="//cdn.embedly.com/widgets/platform.js"charset="UTF-8"></script>
+<script async src="//cdn.embedly.com/widgets/platform.js" charset="UTF-8"></script>
 """.format(url, title)
 
 

--- a/tests/test_mdx_embedly.py
+++ b/tests/test_mdx_embedly.py
@@ -7,7 +7,7 @@ def test_embedly():
     expected = """
 <p>
 <a class="embedly-card" href="https://github.com/yymm">embed.ly</a>
-<script async src="//cdn.embedly.com/widgets/platform.js"charset="UTF-8"></script>
+<script async src="//cdn.embedly.com/widgets/platform.js" charset="UTF-8"></script>
 </p>
     """.strip()
     html = markdown.markdown(s, extensions=[EmbedlyExtension()])


### PR DESCRIPTION
I added a space between attributes of script tag.

According to HTML 5 syntax, it is written as follows:

> Then, the start tag may have a number of attributes, the syntax for which is described below. Attributes must be separated from each other by one or more space characters.

on https://www.w3.org/TR/html5/syntax.html#start-tags